### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Bugly iOS SDK 接入指南
+# Bugly iOS SDK 接入指南
 
 ## 一. SDK 集成
 Bugly提供两种集成方式供iOS开发者选择：

--- a/README_OLD.md
+++ b/README_OLD.md
@@ -97,7 +97,7 @@ func application(application: UIApplication, didFinishLaunchingWithOptions launc
 
 ----
 
-##如何确认成功接入 Bugly ？
+## 如何确认成功接入 Bugly ？
 
 Bugly 会在 log 中输出关键步骤,为了完成接入检测,请在你的 App 代码中手动构建一个异常,如下述例子
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,8 +1,8 @@
-#Bugly 旧版本顺滑升级指引
+# Bugly 旧版本顺滑升级指引
 
 为了SDK接口更加清晰明了，避免使用中的困惑，我们重新梳理调整了Bugly SDK中的接口，请旧版本(< 2.0)用户参照此指引进行升级。
 
-###初始化
+### 初始化
 
 - 导入头文件
 
@@ -40,7 +40,7 @@
 	[Bugly startWithAppId:@"BUGLY_APP_ID" config:config];
 ```
 
-###功能开关
+### 功能开关
 
 **在新版本(2.0 +) Bugly接口中，所有的功能开关均在 BuglyConfig 中设置，请在初始化 Bugly 前先自定义 BuglyConfig**
 
@@ -117,7 +117,7 @@
 	config.symbolicateInProcessEnable = YES;
 ```
 
-###自定义数据
+### 自定义数据
 
 **在新版本(2.0 +) Bugly接口中，部分自定义数据在 BuglyConfig 中设置，请在初始化 Bugly 前先自定义 BuglyConfig。**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
