### PR TITLE
Update Bugly.podspec

### DIFF
--- a/Bugly.podspec
+++ b/Bugly.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.homepage     = "http://bugly.qq.com/"
   s.license      = { :type => "Commercial", :text => "Copyright (C) 2017 Tencent Bugly, Inc. All rights reserved."}
   s.author       = { "Tencent" => "bugly@tencent.com" }
-  s.source       = { :http => "http://softfile.3g.qq.com/myapp/buglysdk/Bugly-2.5.2.zip" }
+  s.source       = { :http => "https://softfile.3g.qq.com/myapp/buglysdk/Bugly-2.5.2.zip" }
   s.requires_arc = true  
   s.platform     = :ios
   s.ios.deployment_target = '7.0'


### PR DESCRIPTION
现在已经有证书了，应该可以使用 https 处理下载，否则 pod install 会有警告
调整 http -> https